### PR TITLE
Fix potential crash on didEndDisplayingCell

### DIFF
--- a/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
+++ b/EssentialApp/EssentialApp.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4619C8262B482707006E43F3 /* EssentialFeed.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4619C7FC2B4826A9006E43F3 /* EssentialFeed.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		4619C8272B482707006E43F3 /* EssentialFeediOS.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4619C8042B4826A9006E43F3 /* EssentialFeediOS.framework */; };
 		4619C8282B482707006E43F3 /* EssentialFeediOS.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4619C8042B4826A9006E43F3 /* EssentialFeediOS.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		461ABFB82B5184BF0050C62A /* UIView+TestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 461ABFB72B5184BF0050C62A /* UIView+TestHelpers.swift */; };
 		46A0BEE82B483CC30063D3A0 /* FeedLoaderWithFallbackCompositeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A0BEE72B483CC30063D3A0 /* FeedLoaderWithFallbackCompositeTests.swift */; };
 		46A0BEF62B484C830063D3A0 /* FeedLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A0BEF52B484C830063D3A0 /* FeedLoaderWithFallbackComposite.swift */; };
 		46A0BEF82B484D2E0063D3A0 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46A0BEF72B484D2E0063D3A0 /* FeedImageDataLoaderWithFallbackComposite.swift */; };
@@ -186,6 +187,7 @@
 		4619C7EB2B481D92006E43F3 /* EssentialAppTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialAppTests.swift; sourceTree = "<group>"; };
 		4619C7F22B4826A9006E43F3 /* EssentialFeed.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = EssentialFeed.xcodeproj; path = ../../EssentialFeed/EssentialFeed.xcodeproj; sourceTree = "<group>"; };
 		4619C8072B4826B7006E43F3 /* EssentialFeed.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = EssentialFeed.xcodeproj; path = ../../EssentialFeed/EssentialFeed.xcodeproj; sourceTree = "<group>"; };
+		461ABFB72B5184BF0050C62A /* UIView+TestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIView+TestHelpers.swift"; sourceTree = "<group>"; };
 		46A0BEE72B483CC30063D3A0 /* FeedLoaderWithFallbackCompositeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackCompositeTests.swift; sourceTree = "<group>"; };
 		46A0BEF52B484C830063D3A0 /* FeedLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
 		46A0BEF72B484D2E0063D3A0 /* FeedImageDataLoaderWithFallbackComposite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedImageDataLoaderWithFallbackComposite.swift; sourceTree = "<group>"; };
@@ -396,6 +398,7 @@
 				46D266A82B51550B00DEA89D /* UIControl+TestHelpers.swift */,
 				46D266A72B51550B00DEA89D /* UIButton+TestHelpers.swift */,
 				46D266AA2B51550B00DEA89D /* UIRefreshControl+TestHelpers.swift */,
+				461ABFB72B5184BF0050C62A /* UIView+TestHelpers.swift */,
 			);
 			path = Controls;
 			sourceTree = "<group>";
@@ -670,6 +673,7 @@
 				46D266B92B5156E100DEA89D /* UIControl+TestHelpers.swift in Sources */,
 				46D266B72B5156D700DEA89D /* UIRefreshControl+TestHelpers.swift in Sources */,
 				46D266B02B51550C00DEA89D /* FeedImageCell+TestHelpers.swift in Sources */,
+				461ABFB82B5184BF0050C62A /* UIView+TestHelpers.swift in Sources */,
 				46A0BEF82B484D2E0063D3A0 /* FeedImageDataLoaderWithFallbackComposite.swift in Sources */,
 				46D266BA2B5156E300DEA89D /* UIImage+TestHelpers.swift in Sources */,
 				4619C7EC2B481D92006E43F3 /* EssentialAppTests.swift in Sources */,

--- a/EssentialApp/EssentialAppTests/Helpers/Controls/UIView+TestHelpers.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/Controls/UIView+TestHelpers.swift
@@ -1,0 +1,15 @@
+//
+//  UIView+TestHelpers.swift
+//  EssentialAppTests
+//
+//  Created by Rebecca Woodman-Halford on 12/01/2024.
+//
+
+import UIKit
+
+extension UIView {
+    func enforceLayoutCycle() {
+        layoutIfNeeded()
+        RunLoop.current.run(until: Date())
+    }
+}

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -19,6 +19,7 @@ extension FeedUIIntegrationTests {
         feed.enumerated().forEach { index, image in
             assertThat(sut, hasViewConfiguredFor: image, at: index, file: file, line: line)
         }
+        executeRunLoopToCleanUpReferences()
     }
     
     func assertThat(_ sut: FeedViewController, hasViewConfiguredFor image: FeedImage, at index: Int, file: StaticString = #file, line: UInt = #line) {
@@ -34,5 +35,9 @@ extension FeedUIIntegrationTests {
         XCTAssertEqual(cell.locationText, image.location, "Expected location text to be \(String(describing: image.location)) for image  view at index (\(index))", file: file, line: line)
 
         XCTAssertEqual(cell.descriptionText, image.description, "Expected description text to be \(String(describing: image.description)) for image view at index (\(index)", file: file, line: line)
+    }
+    
+    private func executeRunLoopToCleanUpReferences() {
+        RunLoop.current.run(until: Date())
     }
 }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests+Assertions.swift
@@ -11,6 +11,7 @@ import EssentialFeediOS
 
 extension FeedUIIntegrationTests {
     func assertThat(_ sut: FeedViewController, isRendering feed: [FeedImage], file: StaticString = #file, line: UInt = #line) {
+        sut.view.enforceLayoutCycle()
         guard sut.numberOfRenderedFeedImageViews() == feed.count else {
             return XCTFail("Expected \(feed.count) images, got \(sut.numberOfRenderedFeedImageViews()) instead.", file: file, line: line)
         }

--- a/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests.swift
+++ b/EssentialApp/EssentialAppTests/Helpers/FeedUIIntegrationTests.swift
@@ -67,6 +67,20 @@ final class FeedUIIntegrationTests: XCTestCase {
         assertThat(sut, isRendering: [image0, image1, image2, image3])
     }
     
+    func test_loadFeedCompletion_rendersSuccessfullyLoadedEmptyFeedAfterNonEmptyFeed() {
+        let image0 = makeImage()
+        let image1 = makeImage()
+        let (sut, loader) = makeSUT()
+
+        sut.loadViewIfNeeded()
+        loader.completeFeedLoading(with: [image0, image1], at: 0)
+        assertThat(sut, isRendering: [image0, image1])
+
+        sut.simulateUserInitiatedFeedReload()
+        loader.completeFeedLoading(with: [], at: 1)
+        assertThat(sut, isRendering: [])
+    }
+    
     func test_loadFeedCompletion_doesNotAlterCurrentRenderingStateOnError() {
         let image0 = makeImage()
         let (sut, loader) = makeSUT()

--- a/EssentialFeed/EssentialFeediOS/FeedUI/Controllers/FeedViewController.swift
+++ b/EssentialFeed/EssentialFeediOS/FeedUI/Controllers/FeedViewController.swift
@@ -14,6 +14,7 @@ public protocol FeedViewControllerDelegate {
 
 public final class FeedViewController: UITableViewController, UITableViewDataSourcePrefetching, FeedLoadingView, FeedErrorView {
     @IBOutlet private(set) public var errorView: ErrorView?
+    private var loadingControllers = [IndexPath: FeedImageCellController]()
     private var onViewIsAppearing: ((FeedViewController) -> Void)?
     public var delegate: FeedViewControllerDelegate?
     
@@ -49,6 +50,7 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
     
     public func display(_ cellControllers: [FeedImageCellController]) {
+        loadingControllers = [:]
         tableModel = cellControllers
     }
     
@@ -87,10 +89,13 @@ public final class FeedViewController: UITableViewController, UITableViewDataSou
     }
 
     private func cellController(forRowAt indexPath: IndexPath) -> FeedImageCellController {
-        return tableModel[indexPath.row]
+        let controller = tableModel[indexPath.row]
+        loadingControllers[indexPath] = controller
+        return controller
     }
     
     private func cancelCellControllerLoad(forRowAt indexPath: IndexPath) {
-        cellController(forRowAt: indexPath).cancelLoad()
+        loadingControllers[indexPath]?.cancelLoad()
+        loadingControllers[indexPath] = nil
     }
 }


### PR DESCRIPTION
[Preventing a Crash when Invalidating Work Based on UITableViewDelegate events](https://academy.essentialdeveloper.com/courses/447455/lectures/17589783)
When updating the table model and reloading the table, UIKit calls didEndDisplayingCell for each removed cell that was previously visible. Since we're canceling requests in this method, we could be sending messages to the new models or potentially crashing in case the new table model has fewer items than the previous one!

This is not a big problem at the moment since items cannot be removed from the feed. But we cannot assume the backend will keep this behavior going further.

